### PR TITLE
BEAN-1621: feature: update add account to company

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
       - [Generate PNG QR Code](#generate-png-qr-code)
       - [Generate SVG QR Code](#generate-svg-qr-code)
       - [Create Company Account](#create-company-account)
+      - [Delete Company Account](#delete-company-account)
       - [Upload Company Account Avatar](#upload-company-account-avatar)
       - [Get Company Account Avatar](#get-company-account-avatar)
   - [Webhook Notifications](#webhook-notifications)
@@ -135,6 +136,11 @@ final avatarBytes = await sdk.getCompanyAccountAvatar(
   avatarId
 );
 // Use avatarBytes to display the image
+
+// Xóa sub-account
+final response = await sdk.deleteCompanyAccount('GCQYCNYU3T73JCQ2J36A3JJ5CUQO4DY4EOKMPUL5723ZH7N6XMMNPAA3');
+log('Deleted account with ID: ${response.account.id}');
+log('Deletion status: ${response.status}');
 ```
 
 # API Reference
@@ -291,7 +297,7 @@ Method Signature:<br>
 
 Parameters:<br>
   - `stellarAccountId`: *The Stellar account ID for the sub-account.*
-  - `name`: *The name of the sub-account in different languages as a Map<String, String> object.*
+  - `name`: *The name of the sub-account in different languages as a LanguageString object.*
 
 Returns:<br>
 `Future<CreateCompanyAccountResponse>`: *A future that resolves with the response object containing the created company account.*
@@ -299,18 +305,40 @@ Returns:<br>
 Return Object Properties:<br>
   - `account`: *The CompanyAccount object representing the created sub-account.*
 
+#### Delete Company Account
+
+*Deletes a sub-account for the company.*
+
+Method Signature:<br>
+*`Future<DeleteCompanyAccountResponse> deleteCompanyAccount(...)`*
+
+Parameters:<br>
+  - `stellarAccountId`: *The Stellar account ID of the sub-account to delete.*
+
+Returns:<br>
+`Future<DeleteCompanyAccountResponse>`: *A future that resolves with the response object containing information about the deleted sub-account.*
+
+Return Object Properties:<br>
+  - `account`: *The CompanyAccount object representing the deleted sub-account.*
+  - `status`: *The status of the deletion operation, typically "deleted".*
+
 Example:<br>
 ```dart
-final name = {
-  'en': "Marketing Account",
-  'vi': "Tài khoản Marketing"
-};
+final name = LanguageString(
+  en: "Marketing Account",
+  vi: "Tài khoản Marketing"
+);
 final response = await sdk.createCompanyAccount(
   "GBZX4364PEPQTDICMIQDZ56K4T75QZCR4NBEYKO6PDRJAHZKGUOJPCXB",
   name
 );
 log('Created company account: ${response.account.id}');
+
+final response = await sdk.deleteCompanyAccount('GCQYCNYU3T73JCQ2J36A3JJ5CUQO4DY4EOKMPUL5723ZH7N6XMMNPAA3');
+log('Deleted account with ID: ${response.account.id}');
+log('Deletion status: ${response.status}');
 ```
+
 
 #### Upload Company Account Avatar
 
@@ -400,6 +428,7 @@ We've added an example that demonstrates how to create and manage company sub-ac
 - Create a new sub-account with multi-language support
 - Upload an avatar for the sub-account
 - Retrieve and display the avatar
+- Delete a sub-account when it's no longer needed
 
 This functionality is particularly useful for businesses that need to manage multiple Stellar accounts under a single company account.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - [Examples](#examples)
   - [Checkout](#checkout)
   - [Deposit](#deposit)
-  - [Sub-account Management](#sub-account-management)
+  - [Account Management](#account-management)
   - [Developer](#developer)
 - [Questions and Answers](#questions-and-answers)
   - [Do I have to use stroops?](#do-i-have-to-use-stroops)
@@ -108,10 +108,10 @@ final response = await merchant.generatePngQRCode('stellarAccountId', 'stellarCu
 log('Generated deeplink: ${response.deeplink}');
 log('Generated PNG QR code: ${response.pngQrCodeBase64String}');
 
-// Create a company sub-account
+// Create a company account
 final name = {
   'en': "Marketing Account",
-  'vi': "Tài khoản Marketing"
+  'vn': "Tài khoản Marketing"
 };
 final accountResponse = await sdk.createCompanyAccount(
   "GBZX4364PEPQTDICMIQDZ56K4T75QZCR4NBEYKO6PDRJAHZKGUOJPCXB",
@@ -119,7 +119,7 @@ final accountResponse = await sdk.createCompanyAccount(
 );
 log('Created company account: ${accountResponse.account.id}');
 
-// Upload avatar for a company sub-account
+// Upload avatar for a company account
 final imageBytes = await File('path_to_image.jpg').readAsBytes();
 final updatedAccount = await sdk.uploadCompanyAccountAvatar(
   "me",
@@ -129,7 +129,7 @@ final updatedAccount = await sdk.uploadCompanyAccountAvatar(
 );
 log('Account updated with avatar: ${updatedAccount.avatarId}');
 
-// Get avatar for a company sub-account
+// Get avatar for a company account
 final avatarBytes = await sdk.getCompanyAccountAvatar(
   "me",
   accountId,
@@ -137,7 +137,7 @@ final avatarBytes = await sdk.getCompanyAccountAvatar(
 );
 // Use avatarBytes to display the image
 
-// Xóa sub-account
+// Delete account
 final response = await sdk.deleteCompanyAccount('GCQYCNYU3T73JCQ2J36A3JJ5CUQO4DY4EOKMPUL5723ZH7N6XMMNPAA3');
 log('Deleted account with ID: ${response.account.id}');
 log('Deletion status: ${response.status}');
@@ -290,36 +290,36 @@ log('Generated SVG QR code: ${response.svgQrCode}');
 
 #### Create Company Account
 
-*Creates a sub-account for the company.*
+*Creates an account for the company.*
 
 Method Signature:<br>
 *`Future<CreateCompanyAccountResponse> createCompanyAccount(...)`*
 
 Parameters:<br>
-  - `stellarAccountId`: *The Stellar account ID for the sub-account.*
-  - `name`: *The name of the sub-account in different languages as a LanguageString object.*
+  - `stellarAccountId`: *The Stellar account ID for the account.*
+  - `name`: *The name of the account in different languages as a LanguageString object.*
 
 Returns:<br>
 `Future<CreateCompanyAccountResponse>`: *A future that resolves with the response object containing the created company account.*
 
 Return Object Properties:<br>
-  - `account`: *The CompanyAccount object representing the created sub-account.*
+  - `account`: *The CompanyAccount object representing the created account.*
 
 #### Delete Company Account
 
-*Deletes a sub-account for the company.*
+*Deletes an account for the company.*
 
 Method Signature:<br>
 *`Future<DeleteCompanyAccountResponse> deleteCompanyAccount(...)`*
 
 Parameters:<br>
-  - `stellarAccountId`: *The Stellar account ID of the sub-account to delete.*
+  - `stellarAccountId`: *The Stellar account ID of the account to delete.*
 
 Returns:<br>
-`Future<DeleteCompanyAccountResponse>`: *A future that resolves with the response object containing information about the deleted sub-account.*
+`Future<DeleteCompanyAccountResponse>`: *A future that resolves with the response object containing information about the deleted account.*
 
 Return Object Properties:<br>
-  - `account`: *The CompanyAccount object representing the deleted sub-account.*
+  - `account`: *The CompanyAccount object representing the deleted account.*
   - `status`: *The status of the deletion operation, typically "deleted".*
 
 Example:<br>
@@ -342,14 +342,14 @@ log('Deletion status: ${response.status}');
 
 #### Upload Company Account Avatar
 
-*Uploads an avatar for a company sub-account.*
+*Uploads an avatar for a company account.*
 
 Method Signature:<br>
 *`Future<CompanyAccount> uploadCompanyAccountAvatar(...)`*
 
 Parameters:<br>
   - `companyId`: *The ID of the company or 'me' for the current company.*
-  - `stellarAccountId`: *The Stellar account ID of the sub-account.*
+  - `stellarAccountId`: *The Stellar account ID of the account.*
   - `imageBytes`: *The image data as Uint8List (bytes).*
   - `mimeType`: *The MIME type of the image (e.g., 'image/jpeg', 'image/png').*
 
@@ -370,14 +370,14 @@ log('Account updated with avatar: ${updatedAccount.avatarId}');
 
 #### Get Company Account Avatar
 
-*Gets the avatar for a company sub-account.*
+*Gets the avatar for a company account.*
 
 Method Signature:<br>
 *`Future<Uint8List> getCompanyAccountAvatar(...)`*
 
 Parameters:<br>
   - `companyId`: *The ID of the company or 'me' for the current company.*
-  - `accountId`: *The ID of the sub-account.*
+  - `accountId`: *The ID of the account.*
   - `avatarId`: *The ID of the avatar.*
 
 Returns:<br>
@@ -422,17 +422,17 @@ We've added an example that showcases a simple deposit flow for a fictional dece
 
 Find the full example code [here](https://github.com/Beans-BV/merchant_sdk_dart/blob/main/example/lib/deposit.dart).
 
-## Sub-account Management
+## Account Management
 
-We've added an example that demonstrates how to create and manage company sub-accounts. This example shows how to:
-- Create a new sub-account with multi-language support
-- Upload an avatar for the sub-account
+We've added an example that demonstrates how to create and manage company accounts. This example shows how to:
+- Create a new account with multi-language support
+- Upload an avatar for the account
 - Retrieve and display the avatar
-- Delete a sub-account when it's no longer needed
+- Delete an account when it's no longer needed
 
 This functionality is particularly useful for businesses that need to manage multiple Stellar accounts under a single company account.
 
-Find the full example code [here](https://github.com/Beans-BV/merchant_sdk_dart/blob/main/example/lib/subaccount.dart).
+Find the full example code [here](https://github.com/Beans-BV/merchant_sdk_dart/blob/main/example/lib/account.dart).
 
 ## Developer
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Method Signature:<br>
 *`Future<Uint8List> getCompanyAccountAvatar(...)`*
 
 Parameters:<br>
-  - `companyId`: *The ID of the company or 'me' for the current company.*
+  - `companyId`: *The ID of the company, or the string "me" to automatically resolve the ID from the provided API token.*
   - `accountId`: *The ID of the account.*
   - `avatarId`: *The ID of the avatar.*
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@
       - [Generate Deeplink](#generate-deeplink)
       - [Generate PNG QR Code](#generate-png-qr-code)
       - [Generate SVG QR Code](#generate-svg-qr-code)
+      - [Create Company Account](#create-company-account)
+      - [Upload Company Account Avatar](#upload-company-account-avatar)
+      - [Get Company Account Avatar](#get-company-account-avatar)
   - [Webhook Notifications](#webhook-notifications)
 - [Examples](#examples)
   - [Checkout](#checkout)
   - [Deposit](#deposit)
+  - [Sub-account Management](#sub-account-management)
   - [Developer](#developer)
 - [Questions and Answers](#questions-and-answers)
   - [Do I have to use stroops?](#do-i-have-to-use-stroops)
@@ -102,6 +106,35 @@ log('Generated SVG QR code: ${response.svgQrCode}');
 final response = await merchant.generatePngQRCode('stellarAccountId', 'stellarCurrencyId', 100, 'memo', 1, 'https://your-domain.com/webhook', 250);
 log('Generated deeplink: ${response.deeplink}');
 log('Generated PNG QR code: ${response.pngQrCodeBase64String}');
+
+// Create a company sub-account
+final name = {
+  'en': "Marketing Account",
+  'vi': "Tài khoản Marketing"
+};
+final accountResponse = await sdk.createCompanyAccount(
+  "GBZX4364PEPQTDICMIQDZ56K4T75QZCR4NBEYKO6PDRJAHZKGUOJPCXB",
+  name
+);
+log('Created company account: ${accountResponse.account.id}');
+
+// Upload avatar for a company sub-account
+final imageBytes = await File('path_to_image.jpg').readAsBytes();
+final updatedAccount = await sdk.uploadCompanyAccountAvatar(
+  "me",
+  "GBZX4364PEPQTDICMIQDZ56K4T75QZCR4NBEYKO6PDRJAHZKGUOJPCXB",
+  imageBytes,
+  "image/jpeg"
+);
+log('Account updated with avatar: ${updatedAccount.avatarId}');
+
+// Get avatar for a company sub-account
+final avatarBytes = await sdk.getCompanyAccountAvatar(
+  "me",
+  accountId,
+  avatarId
+);
+// Use avatarBytes to display the image
 ```
 
 # API Reference
@@ -249,6 +282,89 @@ log('Generated deeplink: ${response.deeplink}');
 log('Generated SVG QR code: ${response.svgQrCode}');
 ```
 
+#### Create Company Account
+
+*Creates a sub-account for the company.*
+
+Method Signature:<br>
+*`Future<CreateCompanyAccountResponse> createCompanyAccount(...)`*
+
+Parameters:<br>
+  - `stellarAccountId`: *The Stellar account ID for the sub-account.*
+  - `name`: *The name of the sub-account in different languages as a Map<String, String> object.*
+
+Returns:<br>
+`Future<CreateCompanyAccountResponse>`: *A future that resolves with the response object containing the created company account.*
+
+Return Object Properties:<br>
+  - `account`: *The CompanyAccount object representing the created sub-account.*
+
+Example:<br>
+```dart
+final name = {
+  'en': "Marketing Account",
+  'vi': "Tài khoản Marketing"
+};
+final response = await sdk.createCompanyAccount(
+  "GBZX4364PEPQTDICMIQDZ56K4T75QZCR4NBEYKO6PDRJAHZKGUOJPCXB",
+  name
+);
+log('Created company account: ${response.account.id}');
+```
+
+#### Upload Company Account Avatar
+
+*Uploads an avatar for a company sub-account.*
+
+Method Signature:<br>
+*`Future<CompanyAccount> uploadCompanyAccountAvatar(...)`*
+
+Parameters:<br>
+  - `companyId`: *The ID of the company or 'me' for the current company.*
+  - `stellarAccountId`: *The Stellar account ID of the sub-account.*
+  - `imageBytes`: *The image data as Uint8List (bytes).*
+  - `mimeType`: *The MIME type of the image (e.g., 'image/jpeg', 'image/png').*
+
+Returns:<br>
+`Future<CompanyAccount>`: *A future that resolves with the updated CompanyAccount object.*
+
+Example:<br>
+```dart
+final imageBytes = await File('path_to_image.jpg').readAsBytes();
+final updatedAccount = await sdk.uploadCompanyAccountAvatar(
+  "me",
+  "GBZX4364PEPQTDICMIQDZ56K4T75QZCR4NBEYKO6PDRJAHZKGUOJPCXB",
+  imageBytes,
+  "image/jpeg"
+);
+log('Account updated with avatar: ${updatedAccount.avatarId}');
+```
+
+#### Get Company Account Avatar
+
+*Gets the avatar for a company sub-account.*
+
+Method Signature:<br>
+*`Future<Uint8List> getCompanyAccountAvatar(...)`*
+
+Parameters:<br>
+  - `companyId`: *The ID of the company or 'me' for the current company.*
+  - `accountId`: *The ID of the sub-account.*
+  - `avatarId`: *The ID of the avatar.*
+
+Returns:<br>
+`Future<Uint8List>`: *A future that resolves with the image data as bytes.*
+
+Example:<br>
+```dart
+final avatarBytes = await sdk.getCompanyAccountAvatar(
+  "me",
+  accountId,
+  avatarId
+);
+// Use avatarBytes to display the image
+```
+
 ## Webhook Notifications
 
 *Beans Merchant API sends a webhook notification to the provided URL when a payment is received.*
@@ -277,6 +393,17 @@ Find the full example code [here](https://github.com/Beans-BV/merchant_sdk_dart/
 We've added an example that showcases a simple deposit flow for a fictional decentralized exchange. This shows you how easy it is to generate a payment request for something like a deposit.
 
 Find the full example code [here](https://github.com/Beans-BV/merchant_sdk_dart/blob/main/example/lib/deposit.dart).
+
+## Sub-account Management
+
+We've added an example that demonstrates how to create and manage company sub-accounts. This example shows how to:
+- Create a new sub-account with multi-language support
+- Upload an avatar for the sub-account
+- Retrieve and display the avatar
+
+This functionality is particularly useful for businesses that need to manage multiple Stellar accounts under a single company account.
+
+Find the full example code [here](https://github.com/Beans-BV/merchant_sdk_dart/blob/main/example/lib/subaccount.dart).
 
 ## Developer
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Method Signature:<br>
 *`Future<CompanyAccount> uploadCompanyAccountAvatar(...)`*
 
 Parameters:<br>
-  - `companyId`: *The ID of the company or 'me' for the current company.*
+  - `companyId`: *The ID of the company, or the string "me" to automatically resolve the ID from the provided API token.*
   - `stellarAccountId`: *The Stellar account ID of the account.*
   - `imageBytes`: *The image data as Uint8List (bytes).*
   - `mimeType`: *The MIME type of the image (e.g., 'image/jpeg', 'image/png').*

--- a/example/lib/account.dart
+++ b/example/lib/account.dart
@@ -6,18 +6,18 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
-class SubAccountScreen extends StatefulWidget {
-  const SubAccountScreen({super.key});
+class AccountScreen extends StatefulWidget {
+  const AccountScreen({super.key});
 
   @override
-  State<SubAccountScreen> createState() => _SubAccountScreenState();
+  State<AccountScreen> createState() => _AccountScreenState();
 }
 
-class _SubAccountScreenState extends State<SubAccountScreen> {
+class _AccountScreenState extends State<AccountScreen> {
   final TextEditingController _stellarAccountIdController =
       TextEditingController();
   final TextEditingController _nameEnController = TextEditingController();
-  final TextEditingController _nameViController = TextEditingController();
+  final TextEditingController _nameVnController = TextEditingController();
   Uint8List? _selectedImageBytes;
   String? _selectedImageMimeType;
   CompanyAccount? _createdAccount;
@@ -25,40 +25,40 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
   bool _isLoading = false;
   bool _isDeleting = false;
   String? _deleteStatus;
-  List<CompanyAccount> _subaccounts = [];
-  bool _isLoadingSubaccounts = false;
+  List<CompanyAccount> _accounts = [];
+  bool _isLoadingAccounts = false;
 
   @override
   void initState() {
     super.initState();
-    _loadSubaccounts();
+    _loadAccounts();
   }
 
   @override
   void dispose() {
     _stellarAccountIdController.dispose();
     _nameEnController.dispose();
-    _nameViController.dispose();
+    _nameVnController.dispose();
     super.dispose();
   }
 
-  Future<void> _loadSubaccounts() async {
+  Future<void> _loadAccounts() async {
     setState(() {
-      _isLoadingSubaccounts = true;
+      _isLoadingAccounts = true;
       _errorMessage = null;
     });
 
     try {
       final sdk = BeansMerchantSdk.staging(apiKey: Constants.beansApiKey);
-      final accounts = await sdk.getMerchantAccounts();
+      final accounts = await sdk.getCompanyAccounts();
       setState(() {
-        _subaccounts = accounts;
-        _isLoadingSubaccounts = false;
+        _accounts = accounts;
+        _isLoadingAccounts = false;
       });
     } catch (e) {
       setState(() {
-        _errorMessage = 'Error loading subaccounts: $e';
-        _isLoadingSubaccounts = false;
+        _errorMessage = 'Error loading accounts: $e';
+        _isLoadingAccounts = false;
       });
     }
   }
@@ -88,10 +88,10 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
     }
   }
 
-  Future<void> _createSubAccount() async {
+  Future<void> _createAccount() async {
     final stellarAccountId = _stellarAccountIdController.text.trim();
     final nameEn = _nameEnController.text.trim();
-    final nameVi = _nameViController.text.trim();
+    final nameVn = _nameVnController.text.trim();
 
     if (stellarAccountId.isEmpty || nameEn.isEmpty) {
       setState(() {
@@ -112,8 +112,8 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
         'en': nameEn,
       };
 
-      if (nameVi.isNotEmpty) {
-        name['vi'] = nameVi;
+      if (nameVn.isNotEmpty) {
+        name['vn'] = nameVn;
       }
 
       final response = await sdk.createCompanyAccount(
@@ -126,8 +126,8 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
         _isLoading = false;
       });
 
-      // Refresh subaccounts list
-      await _loadSubaccounts();
+      // Refresh accounts list
+      await _loadAccounts();
 
       // Upload avatar if an image is selected
       if (_selectedImageBytes != null && _selectedImageMimeType != null) {
@@ -135,7 +135,7 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
       }
     } catch (e) {
       setState(() {
-        _errorMessage = 'Error when creating sub-account: $e';
+        _errorMessage = 'Error when creating account: $e';
         _isLoading = false;
       });
     }
@@ -190,7 +190,7 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
     }
   }
 
-  Future<void> _deleteSubAccount() async {
+  Future<void> _deleteAccount() async {
     if (_createdAccount == null) {
       setState(() {
         _errorMessage = 'No account to delete';
@@ -212,15 +212,15 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
 
       setState(() {
         _deleteStatus =
-            'Sub-account deleted successfully. Status: ${response.status}';
+            'account deleted successfully. Status: ${response.status}';
         _isDeleting = false;
       });
 
-      // Refresh subaccounts list
-      await _loadSubaccounts();
+      // Refresh accounts list
+      await _loadAccounts();
     } catch (e) {
       setState(() {
-        _errorMessage = 'Error when deleting sub-account: $e';
+        _errorMessage = 'Error when deleting account: $e';
         _isDeleting = false;
       });
     }
@@ -230,30 +230,30 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Sub-account management'),
+        title: const Text('account management'),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Subaccounts List Section
+            // Accounts List Section
             const Text(
-              'Existing Sub-accounts',
+              'Existing accounts',
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 16),
-            if (_isLoadingSubaccounts)
+            if (_isLoadingAccounts)
               const Center(child: CircularProgressIndicator())
-            else if (_subaccounts.isEmpty)
-              const Text('No sub-accounts found')
+            else if (_accounts.isEmpty)
+              const Text('No accounts found')
             else
               ListView.builder(
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
-                itemCount: _subaccounts.length,
+                itemCount: _accounts.length,
                 itemBuilder: (context, index) {
-                  final account = _subaccounts[index];
+                  final account = _accounts[index];
                   return Card(
                     child: ListTile(
                       leading: account.avatarId != null
@@ -288,9 +288,9 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
                           if (await showDialog<bool>(
                                 context: context,
                                 builder: (context) => AlertDialog(
-                                  title: const Text('Delete Sub-account'),
+                                  title: const Text('Delete account'),
                                   content: const Text(
-                                    'Are you sure you want to delete this sub-account? This action cannot be undone.',
+                                    'Are you sure you want to delete this account? This action cannot be undone.',
                                   ),
                                   actions: [
                                     TextButton(
@@ -310,7 +310,7 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
                             setState(() {
                               _createdAccount = account;
                             });
-                            await _deleteSubAccount();
+                            await _deleteAccount();
                           }
                         },
                       ),
@@ -322,9 +322,9 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
             const Divider(),
             const SizedBox(height: 16),
 
-            // Create New Sub-account Section
+            // Create New account Section
             const Text(
-              'Create new sub-account',
+              'Create new account',
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 16),
@@ -345,7 +345,7 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
             ),
             const SizedBox(height: 12),
             TextField(
-              controller: _nameViController,
+              controller: _nameVnController,
               decoration: const InputDecoration(
                 labelText: 'Name (Vietnamese - Optional)',
                 border: OutlineInputBorder(),
@@ -376,10 +376,10 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
             SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: _isLoading ? null : _createSubAccount,
+                onPressed: _isLoading ? null : _createAccount,
                 child: _isLoading
                     ? const CircularProgressIndicator(color: Colors.white)
-                    : const Text('Create sub-account'),
+                    : const Text('Create an account'),
               ),
             ),
             if (_errorMessage != null) ...[
@@ -401,11 +401,11 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   const Text(
-                    'Information of created sub-account',
+                    'Information of created an account',
                     style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                   ),
                   ElevatedButton.icon(
-                    onPressed: _isDeleting ? null : _deleteSubAccount,
+                    onPressed: _isDeleting ? null : _deleteAccount,
                     icon: _isDeleting
                         ? const SizedBox(
                             width: 16,
@@ -441,7 +441,7 @@ class _SubAccountScreenState extends State<SubAccountScreen> {
               _buildInfoRow(
                   'Stellar Account ID:', _createdAccount!.stellarAccountId),
               _buildInfoRow('Name (EN):', _createdAccount!.name['en'] ?? 'N/A'),
-              _buildInfoRow('Name (VI):', _createdAccount!.name['vi'] ?? 'N/A'),
+              _buildInfoRow('Name (VN):', _createdAccount!.name['vn'] ?? 'N/A'),
               if (_createdAccount!.avatarId != null) ...[
                 const SizedBox(height: 16),
                 const Text('Avatar:'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
+import 'package:example/account.dart';
 import 'package:example/developer.dart';
-import 'package:example/subaccount.dart';
 import 'package:example/theme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -73,12 +73,12 @@ class DashboardPage extends StatelessWidget {
           ),
           spacer,
           FilledButton.tonal(
-            child: const Text('Sub-account management'),
+            child: const Text('Account management'),
             onPressed: () {
               final navigator = Navigator.of(context);
               navigator.push(
                 MaterialPageRoute(
-                  builder: (context) => const SubAccountScreen(),
+                  builder: (context) => const AccountScreen(),
                 ),
               );
             },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/developer.dart';
+import 'package:example/subaccount.dart';
 import 'package:example/theme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -66,6 +67,18 @@ class DashboardPage extends StatelessWidget {
               navigator.push(
                 MaterialPageRoute(
                   builder: (context) => const DepositScreen(),
+                ),
+              );
+            },
+          ),
+          spacer,
+          FilledButton.tonal(
+            child: const Text('Sub-account management'),
+            onPressed: () {
+              final navigator = Navigator.of(context);
+              navigator.push(
+                MaterialPageRoute(
+                  builder: (context) => const SubAccountScreen(),
                 ),
               );
             },

--- a/example/lib/subaccount.dart
+++ b/example/lib/subaccount.dart
@@ -1,0 +1,305 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:beans_merchant_sdk/beans_merchant_sdk.dart';
+import 'package:example/constants.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class SubAccountScreen extends StatefulWidget {
+  const SubAccountScreen({super.key});
+
+  @override
+  State<SubAccountScreen> createState() => _SubAccountScreenState();
+}
+
+class _SubAccountScreenState extends State<SubAccountScreen> {
+  final TextEditingController _stellarAccountIdController =
+      TextEditingController();
+  final TextEditingController _nameEnController = TextEditingController();
+  final TextEditingController _nameViController = TextEditingController();
+  Uint8List? _selectedImageBytes;
+  String? _selectedImageMimeType;
+  CompanyAccount? _createdAccount;
+  String? _errorMessage;
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _stellarAccountIdController.dispose();
+    _nameEnController.dispose();
+    _nameViController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    try {
+      final picker = ImagePicker();
+      final pickedFile = await picker.pickImage(
+        source: ImageSource.gallery,
+        maxWidth: 800,
+        maxHeight: 800,
+      );
+      if (pickedFile != null) {
+        final bytes = await pickedFile.readAsBytes();
+        setState(() {
+          _selectedImageBytes = bytes;
+          _selectedImageMimeType = 'image/${pickedFile.path.split('.').last}';
+          if (_selectedImageMimeType == 'image/jpg') {
+            _selectedImageMimeType = 'image/jpeg';
+          }
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Error when selecting image: $e';
+      });
+    }
+  }
+
+  Future<void> _createSubAccount() async {
+    final stellarAccountId = _stellarAccountIdController.text.trim();
+    final nameEn = _nameEnController.text.trim();
+    final nameVi = _nameViController.text.trim();
+    
+    if (stellarAccountId.isEmpty || nameEn.isEmpty) {
+      setState(() {
+        _errorMessage = 'Please fill in Stellar Account ID and English name';
+      });
+      return;
+    }
+    
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    
+    try {
+      final sdk = BeansMerchantSdk.staging(apiKey: Constants.companyApiKey);
+      
+      final Map<String, String> name = {
+        'en': nameEn,
+      };
+      
+      if (nameVi.isNotEmpty) {
+        name['vi'] = nameVi;
+      }
+      
+      final response = await sdk.createCompanyAccount(
+        stellarAccountId,
+        name,
+      );
+      
+      setState(() {
+        _createdAccount = response.account;
+        _isLoading = false;
+      });
+      // Upload avatar if an image is selected
+      if (_selectedImageBytes != null && _selectedImageMimeType != null) {
+        _uploadAvatar();
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Error when creating sub-account: $e';
+        _isLoading = false;
+      });
+    }
+  }
+  Future<void> _uploadAvatar() async {
+    if (_createdAccount == null || _selectedImageBytes == null || _selectedImageMimeType == null) {
+      return;
+    }
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    try {
+      final sdk = BeansMerchantSdk.staging(apiKey: Constants.companyApiKey);
+      final updatedAccount = await sdk.uploadCompanyAccountAvatar(
+        'me',
+        _createdAccount!.stellarAccountId,
+        _selectedImageBytes!,
+        _selectedImageMimeType!,
+      );
+      setState(() {
+        _createdAccount = updatedAccount;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Error when uploading avatar: $e';
+        _isLoading = false;
+      });
+    }
+  }
+  Future<Uint8List?> _getAvatar() async {
+    if (_createdAccount?.avatarId == null) {
+      return null;
+    }
+    try {
+      final sdk = BeansMerchantSdk.staging(apiKey: Constants.companyApiKey);
+      return await sdk.getCompanyAccountAvatar(
+        'me',
+        _createdAccount!.id,
+        _createdAccount!.avatarId!,
+      );
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Error when getting avatar: $e';
+      });
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sub-account management'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Create new sub-account',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            // Form to create sub-account
+            TextField(
+              controller: _stellarAccountIdController,
+              decoration: const InputDecoration(
+                labelText: 'Stellar Account ID',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _nameEnController,
+              decoration: const InputDecoration(
+                labelText: 'Name (English)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _nameViController,
+              decoration: const InputDecoration(
+                labelText: 'Name (Vietnamese - Optional)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            // Avatar selection part
+            Row(
+              children: [
+                ElevatedButton.icon(
+                  onPressed: _pickImage,
+                  icon: const Icon(Icons.image),
+                  label: const Text('Select avatar'),
+                ),
+                const SizedBox(width: 16),
+                if (_selectedImageBytes != null)
+                  Container(
+                    width: 60,
+                    height: 60,
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Image.memory(_selectedImageBytes!),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 24),
+              // Create sub-account button
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _isLoading ? null : _createSubAccount,
+                child: _isLoading
+                    ? const CircularProgressIndicator(color: Colors.white)
+                    : const Text('Create sub-account'),
+              ),
+            ),
+            if (_errorMessage != null) ...[
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(8),
+                color: Colors.red.withOpacity(0.1),
+                child: Text(
+                  _errorMessage!,
+                  style: TextStyle(color: Colors.red.shade800),
+                ),
+              ),
+            ],
+            // Display information of created sub-account
+            if (_createdAccount != null) ...[
+              const SizedBox(height: 32),
+              const Divider(),
+              const SizedBox(height: 16),
+              const Text(
+                'Information of created sub-account',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              _buildInfoRow('ID:', _createdAccount!.id),
+              _buildInfoRow('Company ID:', _createdAccount!.companyId),
+              _buildInfoRow('Stellar Account ID:', _createdAccount!.stellarAccountId),
+              _buildInfoRow('Name (EN):', _createdAccount!.name.en ?? 'N/A'),
+              _buildInfoRow('Name (VI):', _createdAccount!.name.vi ?? 'N/A'),
+              if (_createdAccount!.avatarId != null) ...[
+                const SizedBox(height: 16),
+                const Text('Avatar:'),
+                const SizedBox(height: 8),
+                FutureBuilder<Uint8List?>(
+                  future: _getAvatar(),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const CircularProgressIndicator();
+                    }
+                    if (snapshot.hasError || snapshot.data == null) {
+                      return const Text('Unable to load avatar');
+                    }
+                    return Container(
+                      width: 120,
+                      height: 120,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: Colors.grey),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Image.memory(snapshot.data!),
+                    );
+                  },
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+  Widget _buildInfoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 150,
+            child: Text(
+              label,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Expanded(
+            child: Text(value),
+          ),
+        ],
+      ),
+    );
+  }
+} 

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   url_launcher_linux
 )
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -56,6 +56,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -80,6 +88,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -93,6 +133,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "5a1e6fb2c0561958d7e4c33574674bda7b77caaca7a33b758876956f2902eea3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.27"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -127,6 +175,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "8bd392ba8b0c8957a157ae0dc9fcf48c58e6c20908d5880aea1d79734df090e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+22"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: "direct main"
     description:
@@ -191,6 +303,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -405,5 +525,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.10+1
+  image_picker: ^1.0.7
   intl: ^0.19.0
   url_launcher: ^6.3.0
 

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
   url_launcher_windows
 )
 

--- a/lib/beans_merchant_sdk.dart
+++ b/lib/beans_merchant_sdk.dart
@@ -3,6 +3,7 @@ library beans_merchant_sdk;
 export 'src/exceptions/api_exception.dart';
 export 'src/models/company_account.dart';
 export 'src/models/create_company_account_response.dart';
+export 'src/models/delete_company_account_response.dart';
 export 'src/models/fetch_stellar_currencies_response.dart';
 export 'src/models/qr_code_response.dart';
 export 'src/models/stellar_currency.dart';

--- a/lib/beans_merchant_sdk.dart
+++ b/lib/beans_merchant_sdk.dart
@@ -1,7 +1,10 @@
 library beans_merchant_sdk;
 
 export 'src/exceptions/api_exception.dart';
+export 'src/models/company_account.dart';
+export 'src/models/create_company_account_response.dart';
 export 'src/models/fetch_stellar_currencies_response.dart';
 export 'src/models/qr_code_response.dart';
 export 'src/models/stellar_currency.dart';
+export 'src/models/upload_avatar_response.dart';
 export 'src/sdk.dart';

--- a/lib/src/models/company_account.dart
+++ b/lib/src/models/company_account.dart
@@ -1,0 +1,44 @@
+class CompanyAccount {
+  final String id;
+  final String companyId;
+  final String stellarAccountId;
+  final Map<String, String> name;
+  final String? avatarId;
+
+  CompanyAccount({
+    required this.id,
+    required this.companyId,
+    required this.stellarAccountId,
+    required this.name,
+    this.avatarId,
+  });
+
+  factory CompanyAccount.fromJson(Map<String, dynamic> json) {
+    final Map<String, String> nameMap = {};
+    if (json['name'] is Map) {
+      (json['name'] as Map).forEach((key, value) {
+        if (value is String) {
+          nameMap[key.toString()] = value;
+        }
+      });
+    }
+
+    return CompanyAccount(
+      id: json['id'],
+      companyId: json['companyId'],
+      stellarAccountId: json['stellarAccountId'],
+      name: nameMap,
+      avatarId: json['avatarId'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'companyId': companyId,
+      'stellarAccountId': stellarAccountId,
+      'name': name,
+      'avatarId': avatarId,
+    };
+  }
+} 

--- a/lib/src/models/create_company_account_response.dart
+++ b/lib/src/models/create_company_account_response.dart
@@ -1,0 +1,21 @@
+import 'company_account.dart';
+
+class CreateCompanyAccountResponse {
+  final CompanyAccount account;
+
+  CreateCompanyAccountResponse({
+    required this.account,
+  });
+
+  factory CreateCompanyAccountResponse.fromJson(Map<String, dynamic> json) {
+    return CreateCompanyAccountResponse(
+      account: CompanyAccount.fromJson(json['account']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'account': account.toJson(),
+    };
+  }
+} 

--- a/lib/src/models/delete_company_account_response.dart
+++ b/lib/src/models/delete_company_account_response.dart
@@ -1,0 +1,27 @@
+import 'company_account.dart';
+
+/// Response object returned when deleting a company sub-account
+class DeleteCompanyAccountResponse {
+  /// The deleted account
+  final CompanyAccount account;
+  
+  /// The status of the deletion operation
+  final String status;
+
+  DeleteCompanyAccountResponse({
+    required this.account,
+    required this.status,
+  });
+
+  factory DeleteCompanyAccountResponse.fromJson(Map<String, dynamic> json) {
+    return DeleteCompanyAccountResponse(
+      account: CompanyAccount.fromJson(json['account'] as Map<String, dynamic>),
+      status: json['status'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'account': account.toJson(),
+        'status': status,
+      };
+} 

--- a/lib/src/models/delete_company_account_response.dart
+++ b/lib/src/models/delete_company_account_response.dart
@@ -1,10 +1,10 @@
 import 'company_account.dart';
 
-/// Response object returned when deleting a company sub-account
+/// Response object returned when deleting a company account
 class DeleteCompanyAccountResponse {
   /// The deleted account
   final CompanyAccount account;
-  
+
   /// The status of the deletion operation
   final String status;
 
@@ -24,4 +24,4 @@ class DeleteCompanyAccountResponse {
         'account': account.toJson(),
         'status': status,
       };
-} 
+}

--- a/lib/src/models/upload_avatar_response.dart
+++ b/lib/src/models/upload_avatar_response.dart
@@ -1,0 +1,19 @@
+class UploadAvatarResponse {
+  final String avatarId;
+
+  UploadAvatarResponse({
+    required this.avatarId,
+  });
+
+  factory UploadAvatarResponse.fromJson(Map<String, dynamic> json) {
+    return UploadAvatarResponse(
+      avatarId: json['avatarId'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'avatarId': avatarId,
+    };
+  }
+} 

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -7,6 +7,7 @@ import 'package:http_parser/http_parser.dart';
 import 'exceptions/api_exception.dart';
 import 'models/company_account.dart';
 import 'models/create_company_account_response.dart';
+import 'models/delete_company_account_response.dart';
 import 'models/fetch_stellar_currencies_response.dart';
 import 'models/language_string.dart';
 import 'models/qr_code_response.dart';
@@ -283,6 +284,31 @@ class BeansMerchantSdk {
         response.statusCode,
         response,
         'Failed to get company account avatar',
+      );
+    }
+  }
+
+  /// Deletes a sub-account for the company
+  /// 
+  /// [stellarAccountId] The Stellar account ID of the sub-account to delete
+  Future<DeleteCompanyAccountResponse> deleteCompanyAccount(
+    String stellarAccountId,
+  ) async {
+    final response = await httpClient.delete(
+      Uri.parse('$apiBaseUrl/companies/me/sub-accounts/$stellarAccountId'),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Beans-Company-Api-Key': apiKey,
+      },
+    );
+
+    if (response.statusCode == 200) {
+      return DeleteCompanyAccountResponse.fromJson(jsonDecode(response.body));
+    } else {
+      throw ApiException(
+        response.statusCode,
+        response,
+        'Failed to delete company account',
       );
     }
   }

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -9,9 +9,7 @@ import 'models/company_account.dart';
 import 'models/create_company_account_response.dart';
 import 'models/delete_company_account_response.dart';
 import 'models/fetch_stellar_currencies_response.dart';
-import 'models/language_string.dart';
 import 'models/qr_code_response.dart';
-import 'models/upload_avatar_response.dart';
 
 class BeansMerchantSdk {
   BeansMerchantSdk.custom({
@@ -183,7 +181,7 @@ class BeansMerchantSdk {
   }
 
   /// Creates a sub-account for the company
-  /// 
+  ///
   /// [stellarAccountId] The Stellar account ID for the sub-account
   /// [name] The name of the sub-account in different languages as a map where
   /// the key is the language code (e.g., 'en', 'vi') and the value is the name in that language
@@ -215,7 +213,7 @@ class BeansMerchantSdk {
   }
 
   /// Uploads an avatar for a company sub-account
-  /// 
+  ///
   /// [companyId] The ID of the company or 'me' for the current company
   /// [stellarAccountId] The Stellar account ID of the sub-account
   /// [imageBytes] The image data as bytes
@@ -234,7 +232,7 @@ class BeansMerchantSdk {
     request.headers['X-Beans-Company-Api-Key'] = apiKey;
 
     final extension = mimeType.split('/').last;
-    
+
     request.files.add(
       http.MultipartFile.fromBytes(
         'image',
@@ -259,7 +257,7 @@ class BeansMerchantSdk {
   }
 
   /// Gets the avatar for a company sub-account
-  /// 
+  ///
   /// [companyId] The ID of the company or 'me' for the current company
   /// [accountId] The ID of the sub-account
   /// [avatarId] The ID of the avatar
@@ -289,7 +287,7 @@ class BeansMerchantSdk {
   }
 
   /// Deletes a sub-account for the company
-  /// 
+  ///
   /// [stellarAccountId] The Stellar account ID of the sub-account to delete
   Future<DeleteCompanyAccountResponse> deleteCompanyAccount(
     String stellarAccountId,
@@ -309,6 +307,49 @@ class BeansMerchantSdk {
         response.statusCode,
         response,
         'Failed to delete company account',
+      );
+    }
+  }
+
+  /// Fetches all merchant accounts
+  Future<List<CompanyAccount>> getMerchantAccounts() async {
+    final response = await httpClient.get(
+      Uri.parse('$apiBaseUrl/companies/me/accounts'),
+      headers: {
+        'X-Beans-Company-Api-Key': apiKey,
+      },
+    );
+
+    if (response.statusCode == 200) {
+      // Parse the response body and get the accounts array
+      final Map<String, dynamic> jsonMap = jsonDecode(response.body);
+      final List<dynamic> jsonList = jsonMap['accounts'];
+      return jsonList.map((json) => CompanyAccount.fromJson(json)).toList();
+    } else {
+      throw ApiException(
+        response.statusCode,
+        response,
+        'Failed to fetch merchant accounts',
+      );
+    }
+  }
+
+  /// Fetches a specific merchant account by Stellar account ID
+  Future<CompanyAccount> getMerchantAccount(String stellarAccountId) async {
+    final response = await httpClient.get(
+      Uri.parse('$apiBaseUrl/companies/me/accounts/$stellarAccountId'),
+      headers: {
+        'X-Beans-Company-Api-Key': apiKey,
+      },
+    );
+
+    if (response.statusCode == 200) {
+      return CompanyAccount.fromJson(jsonDecode(response.body));
+    } else {
+      throw ApiException(
+        response.statusCode,
+        response,
+        'Failed to fetch merchant account',
       );
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.1
+  http_parser: ^4.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Add Company Sub-Account Management to the Beans Merchant SDK
This PR adds new functionality to manage company sub-accounts and their avatars in the Beans Merchant SDK.
### New Features:
## 1. Create Company Sub-Accounts
- Added createCompanyAccount method to create sub-accounts under a company
- Supports multilingual names through a Map<String, String> structure
- Requires Stellar account ID and name information
## 2. Avatar Management
- Added uploadCompanyAccountAvatar method to upload avatar images for sub-accounts
- Added getCompanyAccountAvatar method to retrieve avatar images
- Supports common image formats with proper MIME type handling
Images are size-limited to 150KB as per API requirements
## 3. Supporting Models
- Created new models to support these operations:
   - CompanyAccount: Represents a company sub-account
   - CreateCompanyAccountResponseDto: Response structure for account creation
- Example Implementation:
   - Added a comprehensive example in subaccount.dart demonstrating:
   - Creating sub-accounts with multilingual support 
   - Uploading avatars using image picker
   - Displaying account information and avatar
- Documentation:
   - Updated README.md with API documentation for the new methods
   - Added example code snippets for each new method
   - Added a new section about sub-account management in the Examples section
This implementation provides a complete solution for managing company sub-accounts through the Beans API, enabling businesses to create and manage multiple Stellar accounts under a single company account with proper visual identity through avatars.